### PR TITLE
Provide error handling for route "/check-class-has-data-quality/{id}"

### DIFF
--- a/src/Controller/DataQualityController.php
+++ b/src/Controller/DataQualityController.php
@@ -90,9 +90,24 @@ class DataQualityController extends FrontendController
                 throw new DataQualityException('class has no data quality.');
             }
 
-            return new JsonResponse(['message' => 'ok'], 200);
+            return new JsonResponse([
+                'result' => ['message' => 'ok'],
+                'error' => null,
+            ], 200);
+
         } catch (Exception $exception) {
-            return new JsonResponse(['message' => $exception->getMessage()], 400);
+
+            if ($exception instanceof DataQualityException) {
+                return new JsonResponse([
+                    'result' => null,
+                    'error' => [
+                        'message' => $exception->getMessage(),
+                        'code' => $exception->getCode()
+                    ],
+                ], 200);
+            }
+
+            return new JsonResponse(['message' => $exception->getMessage()], 500);
         }
     }
 }

--- a/src/Resources/public/js/DataQualityBundle.js
+++ b/src/Resources/public/js/DataQualityBundle.js
@@ -23,41 +23,50 @@ pimcore.plugin.DataQualityBundle = Class.create(pimcore.plugin.admin, {
     if (object.data.general.o_classId !== 'DQC' && object.data.general.o_type === 'object') {
       fetch('/admin/data-quality/check-class-has-data-quality/' + object.id)
         .then((response) => {
-          if (response.status === 200) {
-            var path = '/admin/data-quality/index/' + object.id;
-            var html = '<iframe src="' + path + '" style="width: 100%; height: 100%; border: 0;"></iframe>';
-
-            this.tab = Ext.create('Ext.panel.Panel', {
-              border: false,
-              autoScroll: true,
-              closable: false,
-              iconCls: 'pimcore_icon_charty',
-              bodyCls: 'pimcore_overflow_scrolling',
-              html: html,
-              tbar: {
-                items: [
-                  '->', // Fill
-                  {
-                    xtype: 'button',
-                    text: t('refresh'),
-                    iconCls: 'pimcore_icon_reload',
-                    handler: function () {
-                      var key = "object_" + object.id;
-                      if (pimcore.globalmanager.exists(key)) {
-                        var objectTab = pimcore.globalmanager.get(key);
-                        objectTab.saveToSession(function () {
-                          this.tab.setHtml(html);
-                        }.bind(this));
-                      }
-                    }.bind(this)
-                  }
-                ]
-              }
-            });
-            // this adds the pimcore tab
-            object.tabbar.add([this.tab]);
-            pimcore.layout.refresh();
+          if (response.ok) {
+            return response.json();
+          } else {
+            throw new Error(response.statusText);
           }
+        })
+        .then((json) => {
+          if (json.error) {
+            throw new Error(json.error.message);
+          }
+
+          var path = '/admin/data-quality/index/' + object.id;
+          var html = '<iframe src="' + path + '" style="width: 100%; height: 100%; border: 0;"></iframe>';
+
+          this.tab = Ext.create('Ext.panel.Panel', {
+            border: false,
+            autoScroll: true,
+            closable: false,
+            iconCls: 'pimcore_icon_charty',
+            bodyCls: 'pimcore_overflow_scrolling',
+            html: html,
+            tbar: {
+              items: [
+                '->', // Fill
+                {
+                  xtype: 'button',
+                  text: t('refresh'),
+                  iconCls: 'pimcore_icon_reload',
+                  handler: function () {
+                    var key = "object_" + object.id;
+                    if (pimcore.globalmanager.exists(key)) {
+                      var objectTab = pimcore.globalmanager.get(key);
+                      objectTab.saveToSession(function () {
+                        this.tab.setHtml(html);
+                      }.bind(this));
+                    }
+                  }.bind(this)
+                }
+              ]
+            }
+          });
+          // this adds the pimcore tab
+          object.tabbar.add([this.tab]);
+          pimcore.layout.refresh();
         })
         .catch(() => {
           // do nothing and show nothing


### PR DESCRIPTION
When opening a data object without data-quality-config, the request for route "/check-class-has-data-quality/{id}" responds with an http status code 400 Bad Request. This seems wrong as the request is fine.
Instead, error handling is missing for the provided functionality.

This pull request changes the returned HTTP status code to 200 and provides error handling that is possible with the functionality of the request.